### PR TITLE
chore: add back to deck at end of finish screen

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
   },
   "editor.codeActionsOnSave": {
     "quickfix.biome": "explicit"
-  }
+  },
+  "i18n-ally.localesPaths": ["src/i18n/locales"],
+  "i18n-ally.dirStructure": "dir",
+  "i18n-ally.keystyle": "nested"
 }

--- a/src/components/learning/FinishedLearningView/FinishedLearningView.tsx
+++ b/src/components/learning/FinishedLearningView/FinishedLearningView.tsx
@@ -20,17 +20,21 @@ import { useHotkeys } from "@mantine/hooks";
 import { useSetting } from "../../../logic/Settings";
 import Stat from "../../custom/Stat/Stat";
 import { useRepetitionAccuracy } from "../../../logic/learn";
+import { useTranslation } from "react-i18next";
 
 interface FinishedLearningViewProps {
   ratingsList: number[];
   time: StopwatchResult;
+  deckId: string | undefined;
 }
 
 function FinishedLearningView({
   ratingsList,
   time,
+  deckId,
 }: FinishedLearningViewProps) {
   const navigate = useNavigate();
+  const [t] = useTranslation();
   const [name] = useSetting("name");
 
   const accuracy = useRepetitionAccuracy(ratingsList);
@@ -46,11 +50,11 @@ function FinishedLearningView({
         </ThemeIcon>
         <Title>Congratulations{name && ", " + name}!</Title>
         <Text style={{ textAlign: "center" }}>
-          You learned all cards for today of this deck.
+          {t("learning.finished-congratulations")}
         </Text>
         <Group wrap="nowrap">
           <Stat
-            name="Duration"
+            name={t("learning.finished-duration")}
             value={
               time ? time.minutes + "m " + time.seconds + "s" : "not available"
             }
@@ -59,27 +63,36 @@ function FinishedLearningView({
             width="7rem"
           />
           <Stat
-            name="Accuracy"
+            name={t("learning.finished-accuracy-ratio")}
             value={accuracy ? accuracy + "%" : "not available"}
             icon={IconTrophy}
             color="green"
             width="7rem"
           />
           <Stat
-            name="Repetitions"
+            name={t("learning.finished-repetions-count")}
             value={ratingsList.length}
             icon={IconTallymarks}
             color="blue"
             width="7rem"
           />
         </Group>
-        <Button
-          onClick={() => navigate("/home")}
-          leftSection={<IconHome />}
-          size="md"
-        >
-          Go Home
-        </Button>
+        <Group>
+          <Button
+            onClick={() => navigate(`/deck/${deckId}`)}
+            size="md"
+            variant="subtle"
+          >
+            {t("learning.finished-button-to-deck")}
+          </Button>
+          <Button
+            onClick={() => navigate("/home")}
+            leftSection={<IconHome />}
+            size="md"
+          >
+            {t("learning.finished-button-home")}
+          </Button>
+        </Group>
       </Stack>
     </Center>
   );

--- a/src/components/learning/LearnView/LearnView.tsx
+++ b/src/components/learning/LearnView/LearnView.tsx
@@ -112,6 +112,7 @@ function LearnView() {
           <FinishedLearningView
             ratingsList={controller.ratingsList}
             time={stopwatchResult}
+            deckId={deck?.id}
           />
         </Modal>
       </Flex>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -41,5 +41,13 @@
     "developer": {
       "title": "Developer"
     }
+  },
+  "learning": {
+    "finished-button-home": "Go Home",
+    "finished-button-to-deck": "Back to the deck",
+    "finished-repetions-count": "Repetitions",
+    "finished-accuracy-ratio": "Accuracy",
+    "finished-duration": "Duration",
+    "finished-congratulations": "You learned all cards for today of this deck."
   }
 }


### PR DESCRIPTION
Let's offer a way to go back to the deck once the session is over... even if it's not the primary action

<img width="250" alt="Capture d’écran 2024-02-10 à 00 06 13" src="https://github.com/h16nning/skola/assets/177003/20b31b9e-424e-4c00-9f09-648e0bfdaf3c">

