### PR TITLE
chore: use routing instead of complex location spliting

### DIFF
--- a/src/components/CardManagerView/CardManagerView.tsx
+++ b/src/components/CardManagerView/CardManagerView.tsx
@@ -1,4 +1,4 @@
-import { Group, Space, Stack, TextInput, Title } from "@mantine/core";
+import { Space, Group, Stack, TextInput, Title } from "@mantine/core";
 import { useDebouncedState } from "@mantine/hooks";
 import { IconSearch } from "@tabler/icons-react";
 import { useState } from "react";
@@ -21,7 +21,6 @@ function CardManagerView() {
 
   const location = useLocation();
 
-  const deckGiven = !!deckId;
   const [decks] = useDecks();
 
   const [filter, setFilter] = useDebouncedState<string>("", 250);
@@ -29,8 +28,8 @@ function CardManagerView() {
   const [sort, setSort] = useState<[string, boolean]>(["front", true]);
 
   const [cards] = useCardsWith(
-    (cards) => selectCards(cards, deckGiven, filter, sort, location),
-    [deckGiven, location, filter, sort]
+    (cards) => selectCards(cards, deckId, filter, sort),
+    [deckId, location, filter, sort]
   );
 
   return (
@@ -45,7 +44,11 @@ function CardManagerView() {
         </AppHeaderContent>
       </AppHeaderContent>
       <Group align="end" gap="xs">
-        <SelectDecksHeader label="Showing cards in" decks={decks} />
+        <SelectDecksHeader
+          label="Showing cards in"
+          decks={decks}
+          onSelect={(deckId) => navigate(`/cards/${deckId}`)}
+        />
       </Group>
       <TextInput
         leftSection={<IconSearch size={16} />}

--- a/src/components/custom/SelectDecksHeader.tsx
+++ b/src/components/custom/SelectDecksHeader.tsx
@@ -1,22 +1,22 @@
 import React from "react";
 import { Select, Stack, Text } from "@mantine/core";
 import { Deck } from "../../logic/deck";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 interface SelectDecksHeaderProps {
   label: string;
   disableAll?: boolean;
   decks?: Deck[];
+  onSelect: (deckId: string | null) => void;
 }
 
 export default function SelectDecksHeader({
   decks,
   label,
   disableAll,
+  onSelect,
 }: SelectDecksHeaderProps) {
-  const navigate = useNavigate();
-  const location = useLocation();
-
+  const deckId = useParams().deckId || "";
   return (
     <Stack gap="0.25rem">
       <Text fz="sm" c="dimmed">
@@ -32,11 +32,8 @@ export default function SelectDecksHeader({
             label: deck.name,
           })) ?? []
         )}
-        value={location.pathname.split("/")[2] ?? ""}
-        onChange={(value) => {
-          const pathname = location.pathname.split("/")[1];
-          return navigate(`/${pathname}${value !== "" ? "/" + value : ""}`);
-        }}
+        value={deckId}
+        onChange={(value) => onSelect(value)}
       />
     </Stack>
   );

--- a/src/components/editcard/NewCardsView.tsx
+++ b/src/components/editcard/NewCardsView.tsx
@@ -43,7 +43,12 @@ function NewCardsView() {
           <ActionIcon onClick={() => navigate(-1)}>
             <IconChevronLeft />
           </ActionIcon>
-          <SelectDecksHeader label="Adding cards to" decks={decks} disableAll />
+          <SelectDecksHeader
+            label="Adding cards to"
+            decks={decks}
+            disableAll
+            onSelect={(deckId) => navigate(`/new/${deckId}`)}
+          />
         </Group>
 
         <Select

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { Center, Stack, Tabs, Title } from "@mantine/core";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import CColorSchemeToggle from "./ColorSchemeToggle";
 import {
   IconBolt,
@@ -13,26 +13,17 @@ import {
 import GeneralSettingsView from "./GeneralSettingsView";
 import { useSetting } from "../../logic/Settings";
 import EditingSettingsView from "./EditingSettingsView/EditingSettingsView";
-import { useLocation } from "react-router-dom";
 import AboutSettingsView from "./AboutSettingsView";
 import DatabaseSettingsView from "./DatabaseSettingsView/DatabaseSettingsView";
 import { t } from "i18next";
 import LearnSettingsView from "./LearnSettingsView";
 import { AppHeaderContent } from "../Header/Header";
+import { useNavigate, useParams } from "react-router-dom";
 
 export default function SettingsView() {
-  const [value, setValue] = useState("General");
-  const location = useLocation();
-
-  useEffect(() => {
-    if (location.pathname === "/settings") {
-      setValue("general");
-    } else {
-      setValue(location.pathname.split("/")[2]);
-    }
-  }, [location]);
-
   const [developerMode] = useSetting("developerMode");
+  const navigate = useNavigate();
+  const { section } = useParams();
 
   return (
     <Stack gap="xl" w="100%" maw="600px">
@@ -43,63 +34,36 @@ export default function SettingsView() {
       </AppHeaderContent>
       <Tabs
         orientation="horizontal"
-        defaultValue="General"
         variant="pills"
-        value={value}
+        value={section}
+        defaultValue={"general"}
+        onChange={(value) => navigate(`/settings/${value}`)}
       >
         <Tabs.List>
-          <Tabs.Tab
-            value="general"
-            leftSection={<IconSettings />}
-            onClick={() => setValue("general")}
-          >
+          <Tabs.Tab value="general" leftSection={<IconSettings />}>
             {t("settings.general.title")}
           </Tabs.Tab>
-          <Tabs.Tab
-            value="appearance"
-            leftSection={<IconPalette />}
-            onClick={() => setValue("appearance")}
-          >
+          <Tabs.Tab value="appearance" leftSection={<IconPalette />}>
             {t("settings.appearance.title")}
           </Tabs.Tab>
-          <Tabs.Tab
-            value="editing"
-            leftSection={<IconPencil />}
-            onClick={() => setValue("editing")}
-          >
+          <Tabs.Tab value="editing" leftSection={<IconPencil />}>
             {t("settings.editing.title")}
           </Tabs.Tab>
-          <Tabs.Tab
-            value="learn"
-            leftSection={<IconBolt />}
-            onClick={() => setValue("learn")}
-          >
+          <Tabs.Tab value="learn" leftSection={<IconBolt />}>
             {t("settings.learn.title")}
           </Tabs.Tab>
-          <Tabs.Tab
-            value="database"
-            leftSection={<IconDatabase />}
-            onClick={() => setValue("database")}
-          >
+          <Tabs.Tab value="database" leftSection={<IconDatabase />}>
             {t("settings.database.title")}
           </Tabs.Tab>
-          <Tabs.Tab
-            value="about"
-            leftSection={<IconInfoCircle />}
-            onClick={() => setValue("about")}
-          >
+          <Tabs.Tab value="about" leftSection={<IconInfoCircle />}>
             {t("settings.about.title")}
           </Tabs.Tab>
           {developerMode ? (
-            <Tabs.Tab
-              value="developer"
-              leftSection={<IconBraces />}
-              onClick={() => setValue("developer")}
-            >
+            <Tabs.Tab value="developer" leftSection={<IconBraces />}>
               {t("settings.developer.title")}
             </Tabs.Tab>
           ) : null}
-        </Tabs.List>{" "}
+        </Tabs.List>
         <Tabs.Panel value="general">
           <GeneralSettingsView />
         </Tabs.Panel>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,19 +38,23 @@ const router = createBrowserRouter([
         element: <HomeView />,
       },
       {
-        path: "/settings/*",
+        path: "/settings/:section?",
         element: <SettingsView />,
       },
       {
-        path: "/deck/*",
+        path: "/deck/:deckId",
         element: <DeckView />,
       },
       {
-        path: "/new/*",
+        path: "/deck/:deckId/:params",
+        element: <DeckView />,
+      },
+      {
+        path: "/new/:deckId?",
         element: <NewCardsView />,
       },
       {
-        path: "/learn/*",
+        path: "/learn/:deckId",
         element: <LearnView />,
       },
       {

--- a/src/logic/card_filter.ts
+++ b/src/logic/card_filter.ts
@@ -5,17 +5,15 @@ import { getDeck } from "./deck";
 
 export default async function selectCards(
   cards: Table<Card<CardType>>,
-  deckGiven: boolean,
+  deckId: string | undefined,
   filter: string,
-  sort: [string, boolean],
-  location: any
+  sort: [string, boolean]
 ): Promise<Card<CardType>[] | undefined> {
   let filteredCards:
     | Table<Card<CardType>>
     | Collection<Card<CardType>, IndexableType>
     | Card<CardType>[] = cards;
-  if (deckGiven) {
-    const deckId = location.pathname.split("/")[2];
+  if (deckId) {
     filteredCards =
       (await getDeck(deckId).then((deck) => getCardsOf(deck))) ?? [];
   }

--- a/src/logic/deck.ts
+++ b/src/logic/deck.ts
@@ -4,7 +4,7 @@ import { db } from "./db";
 import { IndexableType } from "dexie";
 import { useLiveQuery } from "dexie-react-hooks";
 import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 export interface Deck {
   id: string;
@@ -209,18 +209,12 @@ export function useDeckFromUrl(): [
   boolean,
   string | undefined,
 ] {
-  const location = useLocation();
-  const [id, setID] = useState<string | undefined>(undefined);
-  const [params, setParams] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    setID(location.pathname.split("/")[2]);
-    setParams(location.pathname.split("/")[3]);
-  }, [location]);
+  const deckId = useParams().deckId;
+  const params = useParams().params;
 
   return useLiveQuery(
-    () => db.decks.get(id ?? "").then((deck) => [deck, true, params]),
-    [id],
+    () => db.decks.get(deckId || "").then((deck) => [deck, true, params]),
+    [deckId],
     [undefined, false, undefined]
   );
 }


### PR DESCRIPTION
Use the router instead of some location path splitting

⚠️ wasn't able to test the `param` thing in the `useDeckFromUrl` because couldn't find a route that used it.

also note: there's just the active={} in navigation missing, because of strange api between mantine & react router I couldn't figure out yet
