### PR TITLE
chore: card editing improvements

### DIFF
--- a/src/components/CardManagerView/CardManagerView.tsx
+++ b/src/components/CardManagerView/CardManagerView.tsx
@@ -1,4 +1,4 @@
-import { Group, Stack, TextInput, Title } from "@mantine/core";
+import { Group, Space, Stack, TextInput, Title } from "@mantine/core";
 import { useDebouncedState } from "@mantine/hooks";
 import { IconSearch } from "@tabler/icons-react";
 import { useState } from "react";
@@ -10,6 +10,7 @@ import CardTable from "../CardTable/CardTable";
 import { AppHeaderContent } from "../Header/Header";
 import SelectDecksHeader from "../custom/SelectDecksHeader";
 import classes from "./CardManagerView.module.css";
+import EditorOptionsMenu from "../editcard/EditorOptionsMenu";
 
 const ALL_DECK_ID = "all";
 function CardManagerView() {
@@ -35,7 +36,13 @@ function CardManagerView() {
   return (
     <Stack style={{ overflow: "hidden", width: "100%", height: "100%" }}>
       <AppHeaderContent>
-        <Title order={3}>Manage Cards</Title>
+        <AppHeaderContent>
+          <Group justify="space-between" gap="xs" wrap="nowrap">
+            <Space />
+            <Title order={3}>Manage Cards</Title>
+            <EditorOptionsMenu />
+          </Group>
+        </AppHeaderContent>
       </AppHeaderContent>
       <Group align="end" gap="xs">
         <SelectDecksHeader label="Showing cards in" decks={decks} />

--- a/src/components/editcard/CardEditor/CardEditor.tsx
+++ b/src/components/editcard/CardEditor/CardEditor.tsx
@@ -95,7 +95,7 @@ function CardEditor({ editor, controls, className }: CardEditorProps) {
             </div>
           )}
           {editor && settings.useBubbleMenu && (
-            <BubbleMenu editor={editor}>
+            <BubbleMenu editor={editor} tippyOptions={{ maxWidth: "none" }}>
               <CardEditorControls controls={controls} editor={editor} />
             </BubbleMenu>
           )}

--- a/src/components/editcard/CardEditor/CardEditorControls.tsx
+++ b/src/components/editcard/CardEditor/CardEditorControls.tsx
@@ -1,7 +1,6 @@
 import classes from "./CardEditor.module.css";
 import { RichTextEditor } from "@mantine/tiptap";
 import AddImageControl from "../AddImageControl";
-import EditorOptionsMenu from "../EditorOptionsMenu";
 import { Box } from "@mantine/core";
 import { useSettings } from "../../../logic/Settings";
 import { Editor } from "@tiptap/react";
@@ -60,10 +59,6 @@ export function CardEditorControls({
       )}
       <RichTextEditor.ControlsGroup tabIndex={-1}>
         {controls}
-      </RichTextEditor.ControlsGroup>
-
-      <RichTextEditor.ControlsGroup tabIndex={-1}>
-        <EditorOptionsMenu />
       </RichTextEditor.ControlsGroup>
     </Box>
   );

--- a/src/components/editcard/CardEditor/DoubleSidedCardEditor.tsx
+++ b/src/components/editcard/CardEditor/DoubleSidedCardEditor.tsx
@@ -92,13 +92,13 @@ function DoubleSidedCardEditor({
     <Stack gap="2rem">
       <Stack gap={0}>
         <Text fz="sm" fw={600}>
-          Field 1
+          Front
         </Text>
         <CardEditor editor={editor1} key="front" className={classes} />
       </Stack>
       <Stack gap={0}>
         <Text fz="sm" fw={600}>
-          Field 2
+          Back
         </Text>
         <CardEditor editor={editor2} key="back" />
       </Stack>

--- a/src/components/editcard/CardMenu.tsx
+++ b/src/components/editcard/CardMenu.tsx
@@ -23,10 +23,11 @@ import { useNavigate } from "react-router-dom";
 
 interface CardMenuProps {
   card: Card<CardType> | undefined;
+  withEdit?: boolean;
   onDelete?: Function;
 }
 
-function CardMenu({ card, onDelete }: CardMenuProps) {
+function CardMenu({ card, onDelete, withEdit = true }: CardMenuProps) {
   const [developerMode] = useSetting("developerMode");
   const navigate = useNavigate();
 
@@ -88,12 +89,14 @@ function CardMenu({ card, onDelete }: CardMenuProps) {
           >
             Move Card
           </Menu.Item>
-          <Menu.Item
-            leftSection={<IconEdit size={16} />}
-            onClick={() => navigate(`/cards/${card.deck}/${card.id}`)}
-          >
-            Edit Card
-          </Menu.Item>
+          {withEdit && (
+            <Menu.Item
+              leftSection={<IconEdit size={16} />}
+              onClick={() => navigate(`/cards/${card.deck}/${card.id}`)}
+            >
+              Edit Card
+            </Menu.Item>
+          )}
           <Menu.Item
             color="red"
             leftSection={<IconTrash size={16} />}

--- a/src/components/editcard/EditCardView.tsx
+++ b/src/components/editcard/EditCardView.tsx
@@ -32,10 +32,15 @@ function CardView({ card }: { card: Card<CardType> }) {
   return (
     <Stack style={{ height: "100%", overflowY: "scroll" }}>
       <Group justify="space-between" wrap="nowrap">
-        <Text fz="xs" fw={600}>
-          Edit Card
-        </Text>
-        <CardMenu card={card} />
+        <Group>
+          <Text fz="xs" fw={600}>
+            Edit Card{" "}
+            <Text c="dimmed" span fz="xs" fw={600}>
+              ({card.content.type})
+            </Text>
+          </Text>
+        </Group>
+        <CardMenu card={card} withEdit={false} />
       </Group>
       {CardEditor}
     </Stack>

--- a/src/components/editcard/EditorOptionsMenu.tsx
+++ b/src/components/editcard/EditorOptionsMenu.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Menu } from "@mantine/core";
 import { IconDots, IconSettings } from "@tabler/icons-react";
-import { RichTextEditor } from "@mantine/tiptap";
 import { useNavigate } from "react-router-dom";
 
 interface EditorOptionsMenuProps {}
@@ -11,16 +10,14 @@ export default function EditorOptionsMenu({}: EditorOptionsMenuProps) {
   return (
     <Menu>
       <Menu.Target>
-        <RichTextEditor.Control tabIndex={-1}>
-          <IconDots />
-        </RichTextEditor.Control>
+        <IconDots />
       </Menu.Target>
       <Menu.Dropdown>
         <Menu.Item
           leftSection={<IconSettings />}
           onClick={() => navigate("/settings/editing")}
         >
-          Edit Options
+          Editing Options
         </Menu.Item>
       </Menu.Dropdown>
     </Menu>

--- a/src/components/editcard/NewCardsView.tsx
+++ b/src/components/editcard/NewCardsView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { ActionIcon, Group, Select, Space, Stack } from "@mantine/core";
+import { ActionIcon, Group, Select, Space, Stack, Title } from "@mantine/core";
 import { IconChevronLeft } from "@tabler/icons-react";
 import { useDeckFromUrl, useDecks } from "../../logic/deck";
 import MissingObject from "../custom/MissingObject";
@@ -7,6 +7,8 @@ import { CardType } from "../../logic/card";
 import { useNavigate } from "react-router-dom";
 import { getUtilsOfType } from "../../logic/CardTypeManager";
 import SelectDecksHeader from "../custom/SelectDecksHeader";
+import { AppHeaderContent } from "../Header/Header";
+import EditorOptionsMenu from "./EditorOptionsMenu";
 
 function NewCardsView() {
   const navigate = useNavigate();
@@ -29,6 +31,13 @@ function NewCardsView() {
 
   return (
     <Stack w="100%" maw="600px" key="stack">
+      <AppHeaderContent>
+        <Group justify="space-between" gap="xs" wrap="nowrap">
+          <Space />
+          <Title order={3}>Add card</Title>
+          <EditorOptionsMenu />
+        </Group>
+      </AppHeaderContent>
       <Group justify="space-between">
         <Group gap="xs" align="end">
           <ActionIcon onClick={() => navigate(-1)}>


### PR DESCRIPTION
small improvement:

- move edit options to screen options (instead on every toolbar)
- align double sided labels for consistency
- Add title for add card screen
- avoid scrolling the tip as it hide options (i took a loooong time seeing options there)