### PR TITLE
feat(ui): add placeholder when new decks

### DIFF
--- a/src/components/CardTable/CardTable.tsx
+++ b/src/components/CardTable/CardTable.tsx
@@ -1,11 +1,13 @@
 import classes from "./CardTable.module.css";
 import React from "react";
 import { Card, CardType } from "../../logic/card";
-import { Table, Text } from "@mantine/core";
+import { Stack, Table, Text } from "@mantine/core";
 import { useEventListener } from "@mantine/hooks";
 import CardTableHeadItem from "./CardTableHeadItem";
 import { CardTableItem } from "./CardTableItem";
 import { SortOption } from "../../logic/card_filter";
+import { useTranslation } from "react-i18next";
+import { IconCards } from "@tabler/icons-react";
 
 interface CardTableProps {
   cardSet: Card<CardType>[];
@@ -26,6 +28,7 @@ function CardTable({
   sort,
   setSort,
 }: CardTableProps) {
+  const [t] = useTranslation();
   const ref = useEventListener("keydown", (event) => {
     if (event.key === "ArrowDown") {
       setSelectedIndex(
@@ -86,26 +89,28 @@ function CardTable({
             />
           </Table.Tr>
         </Table.Thead>
-        {cardSet.length > 0 ? (
-          <Table.Tbody>
-            {cardSet.map((card, index) => (
-              <CardTableItem
-                card={card}
-                key={card.id}
-                index={index}
-                selectedIndex={selectedIndex}
-                setSelectedIndex={setSelectedIndex}
-                selectedCard={selectedCard}
-                setSelectedCard={setSelectedCard}
-              />
-            ))}
-          </Table.Tbody>
-        ) : (
-          <Text fz="sm" c="dimmed">
-            No cards found
-          </Text>
-        )}
+        <Table.Tbody>
+          {cardSet.map((card, index) => (
+            <CardTableItem
+              card={card}
+              key={card.id}
+              index={index}
+              selectedIndex={selectedIndex}
+              setSelectedIndex={setSelectedIndex}
+              selectedCard={selectedCard}
+              setSelectedCard={setSelectedCard}
+            />
+          ))}
+        </Table.Tbody>
       </Table>
+      {cardSet.length === 0 && (
+        <Stack align="center" p="xl">
+          <IconCards size={36} strokeWidth={1.5} color="lightgray" />
+          <Text fz="sm" c="dimmed">
+            {t("manage-cards.table.no-cards-found")}
+          </Text>
+        </Stack>
+      )}
     </Table.ScrollContainer>
   );
 }

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -1,6 +1,6 @@
-import { Button, Center, Stack, Title } from "@mantine/core";
+import { Button, Center, Stack, Text, Title } from "@mantine/core";
 import { useHotkeys } from "@mantine/hooks";
-import { IconPlus } from "@tabler/icons-react";
+import { IconFolder, IconPlus } from "@tabler/icons-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSetting } from "../logic/Settings";
@@ -29,16 +29,32 @@ export default function HomeView({}: {}) {
         </Center>
       </AppHeaderContent>
 
-      <Stack gap="xs" w="600px" maw="100%" align="flex-end" pt="xl">
-        <Button
-          onClick={() => setNewDeckModalOpened(true)}
-          leftSection={<IconPlus />}
-          variant="default"
-        >
-          {t("deck.new-deck-button")}
-        </Button>
-        <DeckTable deckList={decks} isReady={isReady} />
-      </Stack>
+      {isReady && decks?.length === 0 ? (
+        <Stack align="center" p="xl">
+          <IconFolder size={80} strokeWidth={1.5} color="lightgray" />
+          <Text fz="md" c="dimmed">
+            {t("home.no-decks-found")}
+          </Text>
+          <Button
+            onClick={() => setNewDeckModalOpened(true)}
+            leftSection={<IconPlus />}
+            variant="primary"
+          >
+            {t("home.create-deck")}
+          </Button>
+        </Stack>
+      ) : (
+        <Stack gap="xs" w="600px" maw="100%" align="flex-end" pt="xl">
+          <Button
+            onClick={() => setNewDeckModalOpened(true)}
+            leftSection={<IconPlus />}
+            variant="default"
+          >
+            {t("deck.new-deck-button")}
+          </Button>
+          <DeckTable deckList={decks} isReady={isReady} />
+        </Stack>
+      )}
       <NewDeckModal
         opened={newDeckModalOpened}
         setOpened={setNewDeckModalOpened}

--- a/src/components/deck/DeckTable.tsx
+++ b/src/components/deck/DeckTable.tsx
@@ -3,6 +3,7 @@ import { Text, Stack } from "@mantine/core";
 import DeckPreview from "./DeckPreview";
 import { Deck } from "../../logic/deck";
 import LazySkeleton from "../custom/LazySkeleton";
+import { useTranslation } from "react-i18next";
 
 interface DeckTableProps {
   deckList?: Deck[];
@@ -10,6 +11,7 @@ interface DeckTableProps {
 }
 
 function DeckTable({ deckList, isReady }: DeckTableProps) {
+  const [t] = useTranslation();
   return isReady && deckList ? (
     deckList.length !== 0 ? (
       <Stack gap="0" w="100%">
@@ -21,8 +23,7 @@ function DeckTable({ deckList, isReady }: DeckTableProps) {
       </Stack>
     ) : (
       <Text fz="sm" c="dimmed" pt="lg" ta="center">
-        You have not created any decks yet. Click the button above to create
-        one!
+        {t("deck.no-decks-found")}
       </Text>
     )
   ) : (

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -50,6 +50,7 @@
       "new-subdeck": "Create New Subdeck in {{superDeck}}",
       "submit": "Create"
     },
+    "no-decks-found": "There are no deck here. Click the button above to create one!",
     "notebook": {
       "title": "Notebook"
     },
@@ -76,6 +77,8 @@
     "no-cards-title": "It is looking empty here!"
   },
   "home": {
+    "create-deck": "Create a deck",
+    "no-decks-found": "You have not created any decks yet.",
     "title": "Home",
     "welcome": "Welcome!",
     "welcome-user": "Welcome back, {{name}}!"
@@ -91,6 +94,9 @@
     "finished-repetions-count": "Repetitions"
   },
   "manage-cards": {
+    "table": {
+      "no-cards-found": "No cards found"
+    },
     "title": "Manage Cards"
   },
   "notebook": {


### PR DESCRIPTION
It started as react was 🔴  because of `<p>` inside table which is illegal... so i moved it around, but then i wanted to make it a bit nicer... 

here is a proposition

i started with MangeView, and Homeview, but eventually might do elsewhere

<img width="546" alt="Capture d’écran 2024-02-25 à 18 42 48" src="https://github.com/h16nning/skola/assets/177003/6b797bce-dd65-4d44-bf94-a39cd47da240">
