### PR TITLE
fix: notebook sort and note menu event propagation

### DIFF
--- a/src/components/notebook/NotebookCard.tsx
+++ b/src/components/notebook/NotebookCard.tsx
@@ -54,13 +54,13 @@ const InnerCard = memo(
     const [answerToggled, setAnswerToggled] = useState(false);
 
     return (
-      <Paper
-        p="md"
-        className={classes.card}
-        onClick={() => setAnswerToggled(!answerToggled)}
-      >
+      <Paper p="md" className={classes.card}>
         <Group align="top" justify="space-between" wrap="nowrap">
-          <Group align="center" w="100%">
+          <Group
+            align="center"
+            w="100%"
+            onClick={() => setAnswerToggled(!answerToggled)}
+          >
             {getUtils(note).displayNote(
               note,
               showAnswer ? "strict" : answerToggled ? "facultative" : "none"

--- a/src/components/notebook/NotebookCard.tsx
+++ b/src/components/notebook/NotebookCard.tsx
@@ -1,6 +1,7 @@
 import { Draggable } from "@hello-pangea/dnd";
 import { Group, Paper } from "@mantine/core";
-import { memo, useEffect, useState } from "react";
+import { useDisclosure } from "@mantine/hooks";
+import { memo, useEffect } from "react";
 import { getUtils } from "../../logic/TypeManager";
 import { CardType } from "../../logic/card";
 import { Note, updateNote } from "../../logic/note";
@@ -51,16 +52,12 @@ export default memo(NotebookCard);
 
 const InnerCard = memo(
   ({ note, showAnswer }: { note: Note<CardType>; showAnswer: boolean }) => {
-    const [answerToggled, setAnswerToggled] = useState(false);
+    const [answerToggled, handlers] = useDisclosure(false);
 
     return (
       <Paper p="md" className={classes.card}>
         <Group align="top" justify="space-between" wrap="nowrap">
-          <Group
-            align="center"
-            w="100%"
-            onClick={() => setAnswerToggled(!answerToggled)}
-          >
+          <Group align="center" w="100%" onClick={handlers.toggle}>
             {getUtils(note).displayNote(
               note,
               showAnswer ? "strict" : answerToggled ? "facultative" : "none"

--- a/src/components/notebook/NotebookView.tsx
+++ b/src/components/notebook/NotebookView.tsx
@@ -27,15 +27,6 @@ import { useDeckFromUrl } from "../../logic/deck";
 import { Note, useNotesOf } from "../../logic/note";
 import NotebookCard from "./NotebookCard";
 
-async function sortNotes(
-  notes: Note<CardType>[],
-  sortFunction: NoteSortFunction,
-  sortOrder: 1 | -1,
-  setSortedCards: (cards: Note<CardType>[]) => void
-) {
-  setSortedCards(notes.sort(sortFunction(sortOrder)));
-}
-
 export default function NotebookView() {
   const [deck] = useDeckFromUrl();
 
@@ -44,6 +35,7 @@ export default function NotebookView() {
 
   const [notes] = useNotesOf(deck, excludeSubDecks);
 
+  const [sortOption, setSortOption] = useState<SortOption>(sortOptions[0]);
   const [sortOrder] = useState<1 | -1>(1);
   const [sortedNotes, setSortedNotes] = useState<Note<CardType>[]>(notes ?? []);
 
@@ -58,12 +50,10 @@ export default function NotebookView() {
     }
   }, [sortedNotes]);
 
-  const [sortOption, setSortOption] = useState<SortOption>(sortOptions[0]);
-
   useEffect(() => {
     setUseCustomSort(sortOption.value === "custom_order");
-    sortNotes(notes ?? [], sortOption.sortFunction, sortOrder, setSortedNotes);
-  }, [notes, sortOption, sortOrder]);
+    setSortedNotes((notes ?? []).sort(sortOption.sortFunction(sortOrder)));
+  }, [notes, sortOption, sortOrder, setSortedNotes]);
 
   return (
     <Stack gap="sm">
@@ -105,6 +95,7 @@ export default function NotebookView() {
         </DragDropContext>
       ) : (
         <Stack gap="xs">
+          {sortOption.label}
           {sortedNotes.map((note, index) => (
             <NotebookCard
               key={note.id}

--- a/src/components/notebook/NotebookView.tsx
+++ b/src/components/notebook/NotebookView.tsx
@@ -52,7 +52,9 @@ export default function NotebookView() {
 
   useEffect(() => {
     setUseCustomSort(sortOption.value === "custom_order");
-    setSortedNotes((notes ?? []).sort(sortOption.sortFunction(sortOrder)));
+    setSortedNotes(
+      (notes ?? []).slice(0).sort(sortOption.sortFunction(sortOrder))
+    );
   }, [notes, sortOption, sortOrder, setSortedNotes]);
 
   return (
@@ -95,7 +97,6 @@ export default function NotebookView() {
         </DragDropContext>
       ) : (
         <Stack gap="xs">
-          {sortOption.label}
           {sortedNotes.map((note, index) => (
             <NotebookCard
               key={note.id}


### PR DESCRIPTION
- fix: as .sort() doesn't create a new array, updating sortedNotes state didn't happen as expected
- fix: moved onclick event listener for toggling note answer to a sibling elem of note menu; to avoid click event conflicts (before clicking on the three dots or menu items would trigger toggle answer)