### PR TITLE
feat: allow import from paste

### DIFF
--- a/src/app/NoteTable/NoteTableItem.tsx
+++ b/src/app/NoteTable/NoteTableItem.tsx
@@ -1,11 +1,11 @@
 import { getAdapter } from "@/logic/NoteTypeAdapter";
+import { NoteTypeLabels } from "@/logic/card/card";
 import { useDeckOf } from "@/logic/deck/hooks/useDeckOf";
 import { NoteType } from "@/logic/note/note";
+import { Note } from "@/logic/note/note";
 import { Table } from "@mantine/core";
 import cx from "clsx";
 import { useEffect } from "react";
-import { NoteTypeLabels } from "@/logic/card/card";
-import { Note } from "@/logic/note/note";
 import classes from "./NoteTable.module.css";
 
 export function NoteTableItem({

--- a/src/app/settings/importexport/ImportFromPaste.tsx
+++ b/src/app/settings/importexport/ImportFromPaste.tsx
@@ -1,0 +1,58 @@
+import { Stack, TextInput, Textarea } from "@mantine/core";
+import { useEffect, useState } from "react";
+import ImportButton from "./ImportButton";
+import { ImportFromSourceProps } from "./ImportModal";
+import { importCards } from "./importLogic";
+
+interface ImportFromPasteProps extends ImportFromSourceProps {}
+
+export default function ImportFromPaste({
+  importStatus,
+  setImportStatus,
+  deck,
+}: ImportFromPasteProps) {
+  const [pastedText, setPastedText] = useState<string>("");
+  const [cardSeparator] = useState<string>("\n");
+  const [questionAnswerSeperator, setQuestionAnswerSeperator] =
+    useState<string>("\t");
+
+  // Clear textarea after successful import
+  useEffect(() => {
+    if (importStatus === "success") {
+      setPastedText("");
+    }
+  }, [importStatus]);
+
+  return (
+    <Stack align="start">
+      <Textarea
+        label="Paste your cards here"
+        placeholder="Question1&#9;Answer1&#10;Question2&#9;Answer2&#10;..."
+        value={pastedText}
+        onChange={(e) => setPastedText(e.currentTarget.value)}
+        minRows={8}
+        autosize
+        style={{ width: "100%" }}
+      />
+      <TextInput
+        label="Question / Answer Separator"
+        value={questionAnswerSeperator}
+        onChange={(e) => setQuestionAnswerSeperator(e.currentTarget.value)}
+        description="Default is Tab character. Change if your data uses a different separator."
+      />
+      <ImportButton
+        importFunction={async () => {
+          await importCards(
+            pastedText,
+            deck,
+            cardSeparator,
+            questionAnswerSeperator
+          );
+        }}
+        importStatus={importStatus}
+        setImportStatus={setImportStatus}
+        disabled={!pastedText.trim() || !deck}
+      />
+    </Stack>
+  );
+}

--- a/src/app/settings/importexport/ImportFromPlainText.tsx
+++ b/src/app/settings/importexport/ImportFromPlainText.tsx
@@ -1,39 +1,11 @@
-import { getAdapterOfType } from "@/logic/NoteTypeAdapter";
-import { Deck } from "@/logic/deck/deck";
-import { NoteType } from "@/logic/note/note";
 import { Stack, TextInput } from "@mantine/core";
 import { useState } from "react";
 import FileImport from "./FileImport";
 import ImportButton from "./ImportButton";
 import { ImportFromSourceProps } from "./ImportModal";
+import { importCards } from "./importLogic";
 
 interface ImportFromPlainTextProps extends ImportFromSourceProps {}
-
-async function importCards(
-  fileText: string | null,
-  deck: Deck | undefined,
-  cardSeparator: string,
-  questionAnswerSeperator: string
-) {
-  if (!fileText || !deck) {
-    return;
-  }
-  const questionAnswerPairs = fileText.split(cardSeparator).map((line) => {
-    return line.split(questionAnswerSeperator);
-  });
-
-  await Promise.all(
-    questionAnswerPairs.map(async (pair) => {
-      return getAdapterOfType(NoteType.Basic).createNote(
-        {
-          front: pair[0],
-          back: pair[1],
-        },
-        deck
-      );
-    })
-  );
-}
 
 export default function ImportFromPlainText({
   file,

--- a/src/app/settings/importexport/ImportModal.tsx
+++ b/src/app/settings/importexport/ImportModal.tsx
@@ -3,8 +3,9 @@ import React, { useState } from "react";
 import ModalProps from "../../../components/ModalProps";
 import { Deck } from "../../../logic/deck/deck";
 
-import { IconJson, IconTxt } from "@tabler/icons-react";
+import { IconClipboardText, IconJson, IconTxt } from "@tabler/icons-react";
 import ImportFromJSON from "./ImportFromJSON";
+import ImportFromPaste from "./ImportFromPaste";
 import ImportFromPlainText from "./ImportFromPlainText";
 
 interface ImportModalProps extends ModalProps {
@@ -28,7 +29,7 @@ export default function ImportModal({
   setOpened,
   deck,
 }: ImportModalProps) {
-  const [tab, setTab] = useState("cardsfromplaintext");
+  const [tab, setTab] = useState("cardsfrompaste");
   const [file, setFile] = useState<File | null>(null);
   const [fileText, setFileText] = useState<string | null>(null);
   const [importStatus, setImportStatus] = useState<ImportStatus>("passive");
@@ -52,6 +53,13 @@ export default function ImportModal({
         >
           <Tabs.List>
             <Tabs.Tab
+              value="cardsfrompaste"
+              leftSection={<IconClipboardText />}
+              onClick={() => setTab("cardsfrompaste")}
+            >
+              From Paste
+            </Tabs.Tab>
+            <Tabs.Tab
               value="cardsfromplaintext"
               leftSection={<IconTxt />}
               onClick={() => setTab("cardsfromplaintext")}
@@ -66,6 +74,17 @@ export default function ImportModal({
               From JSON
             </Tabs.Tab>
           </Tabs.List>
+          <Tabs.Panel value="cardsfrompaste">
+            <ImportFromPaste
+              file={file}
+              setFile={setFile}
+              fileText={fileText}
+              setFileText={setFileText}
+              deck={deck}
+              importStatus={importStatus}
+              setImportStatus={setImportStatus}
+            />
+          </Tabs.Panel>
           <Tabs.Panel value="cardsfromplaintext">
             <ImportFromPlainText
               file={file}
@@ -90,7 +109,7 @@ export default function ImportModal({
           </Tabs.Panel>
         </Tabs>
       )}
-      {importStatus}
+      {importStatus !== "passive" && importStatus}
     </Modal>
   );
 }

--- a/src/app/settings/importexport/importLogic.ts
+++ b/src/app/settings/importexport/importLogic.ts
@@ -1,0 +1,35 @@
+import { getAdapterOfType } from "@/logic/NoteTypeAdapter";
+import { Deck } from "@/logic/deck/deck";
+import { NoteType } from "@/logic/note/note";
+
+export async function importCards(
+  text: string | null,
+  deck: Deck | undefined,
+  cardSeparator: string,
+  questionAnswerSeperator: string
+) {
+  if (!text || !deck) {
+    return;
+  }
+  const questionAnswerPairs = text
+    .split(cardSeparator)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      return line.split(questionAnswerSeperator);
+    });
+
+  await Promise.all(
+    questionAnswerPairs.map(async (pair) => {
+      if (pair.length < 2) return; 
+      return getAdapterOfType(NoteType.Basic).createNote(
+        {
+          front: pair[0],
+          back: pair[1],
+        },
+        deck
+      );
+    })
+  );
+}
+


### PR DESCRIPTION
## Summary
Added the ability to import cards by pasting text directly, alongside the existing file upload method. This simplifies the workflow for users who want to import data from their clipboard without creating an intermediate CSV file. For example I usually learn from LLMs. At the end of chat, I can ask the LLM to generate flashcards, which I can copy paste and import. 

## UI Changes

- **New Import Tab:** Added "From Paste" tab with clipboard icon, set as default first tab
- **Textarea Component:** Created `ImportFromPaste` component with:
  - Textarea (8 rows, auto-sizing) for pasting question-answer pairs
  - Configurable separator input (default: Tab)
  - Auto-clear after successful import
- **Modal Updates:** 
  - Import status text only displays when not in passive state (hidden on input tabs)
  - Added new tab alongside existing "From Plain Text" and "From JSON" tabs

## Logic Changes

- **Import Logic:** Enhanced `importLogic.ts` to filter empty lines and trim whitespace
- **Component:** `ImportFromPaste` manages local state and reuses existing `importCards` function
- **Flow:** Text split by newline → each line split by separator → empty lines filtered → cards created in parallel

## Testing Instructions
1. Open the **Import Cards** modal in Skola.
2. Select the new **"Paste Text"** option.
3. Paste a list of question (e.g., `question:answer`) and hit **Submit**.
4. Confirm cards are created successfully in the dashboard.